### PR TITLE
Add offline electron build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ Berto is an AI-powered terminal assistant that makes the command line accessible
 5. **Open your browser**
    Go to [http://localhost:3000](http://localhost:3000)
 
+## 🖥️ Electron Desktop App
+
+Build a standalone desktop version that only relies on your OpenAI API key:
+
+```bash
+# Build the static web app and package Electron
+pnpm run build-electron
+
+# macOS example output is in the `dist` folder
+open dist
+```
+
+Run the resulting `.dmg` on macOS or share it with others. The app works
+offline and communicates only with OpenAI for AI features.
+
 ## 🎯 How to Use Berto
 
 ### Natural Language Commands

--- a/main.js
+++ b/main.js
@@ -27,13 +27,13 @@ function createWindow() {
   // Load the app
   const isDev = process.argv.includes('--dev');
   if (isDev) {
-    win.loadURL('http://localhost:3001'); // Use port 3001 as shown in your logs
+    win.loadURL('http://localhost:3001'); // Use port 3001 in dev mode
     win.webContents.openDevTools();
   } else {
-    // For production builds, connect to Vercel deployment
-    const productionUrl = 'https://berto-psi.vercel.app/';
-    console.log(`Loading production app from: ${productionUrl}`);
-    win.loadURL(productionUrl);
+    // Load the static build packaged with the app
+    const indexPath = path.join(__dirname, 'out', 'index.html');
+    console.log(`Loading local file: ${indexPath}`);
+    win.loadFile(indexPath);
   }
 
   // Inject Electron identifier after page loads

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "next start",
     "electron": "electron .",
     "electron-dev": "electron . --dev",
-    "build-electron": "next build && electron-builder",
+    "build-electron": "STATIC_BUILD=true next build && electron-builder",
     "dist": "pnpm run build && pnpm run build-electron"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- allow Electron to load the local static build in production
- build Electron with STATIC_BUILD flag for offline package
- document how to build the macOS app

## Testing
- `npm run lint` *(fails: asks for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_685b7cebace883268e0a3bda0a6f7840