### PR TITLE
Fix vercel.json formatting

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,5 +13,5 @@
   },
   "env": {
     "OPENAI_API_KEY": "@openai_api_key"
-  },
+  }
 } 


### PR DESCRIPTION
## Summary
- fix trailing commas in vercel.json so it parses correctly

## Testing
- `bash test-build.sh` *(fails: `ELIFECYCLE Command failed with exit code 1`)*

------
https://chatgpt.com/codex/tasks/task_b_685c27668900832697473a517f27e623