### PR TITLE
Expand web hack game

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,12 @@ Experience Berto's interactive cyber security challenge:
 
 ```bash
 hack                      # Start the challenge
-cd intel                  # Navigate to intel directory  
+cd intel                  # Navigate to intel directory
 cat CODE_1.dat           # Find your first access code
 cat ../matrix.dat        # Decode the matrix for CODE_2
 cd ../vault              # Enter the final vault challenge
+cd ../level2             # Optional side quest
+cat puzzle.txt           # Solve the riddle for extra glory
 ```
 
 **Features:**
@@ -99,6 +101,9 @@ cd ../vault              # Enter the final vault challenge
 - 🧭 **Full Navigation**: Complete `cd` support for directory exploration
 - 🤖 **AI-Generated Content**: Dynamic hints and responses
 - 🎯 **Educational**: Learn real terminal commands while playing
+- 🎮 **Side Quests**: Explore `level2` for optional puzzles
+- 🏆 **Scoreboard**: Add your alias to `scoreboard.txt`
+- 🔁 **Replayable**: AI randomizes hints for new runs
 
 ---
 

--- a/app/api/execute/route.ts
+++ b/app/api/execute/route.ts
@@ -75,6 +75,10 @@ export async function POST(req: NextRequest) {
    - Enter the vault with the secret password
    - Complete the puzzle for CODE_3
 
+▶ BONUS LEVEL:
+   - Explore 'level2' for an optional side quest
+   - Add your alias to 'scoreboard.txt'
+
 Once you have all 3 codes, check 'victory.txt'!
 
 💡 HINTS:
@@ -227,12 +231,14 @@ Once you have all 3 codes, check 'victory.txt'!
           '-rwxr-xr-x 1 games games  512 Dec 25 12:00 start_hack.sh',
           'drwxr-xr-x 1 games games 4096 Dec 25 12:00 intel',
           '-rw-r--r-- 1 games games  334 Dec 25 12:00 matrix.dat',
+          'drwxr-xr-x 1 games games 4096 Dec 25 12:00 level2',
           'drwx------ 1 games games 4096 Dec 25 12:00 vault',
+          '-rw-r--r-- 1 games games  138 Dec 25 12:00 scoreboard.txt',
           '-rw-r--r-- 1 games games  445 Dec 25 12:00 victory.txt'
         ];
         
         return NextResponse.json({
-          stdout: `total 8\n${hackFiles.join('\n')}`,
+          stdout: `total 10\n${hackFiles.join('\n')}`,
           stderr: '',
           exitCode: 0,
           success: true,
@@ -252,6 +258,22 @@ Once you have all 3 codes, check 'victory.txt'!
         
         return NextResponse.json({
           stdout: `🕵️ INTEL DIRECTORY - CLASSIFIED FILES\n\ntotal 12\n${intelFiles.join('\n')}\n\n💡 Try: cat mission_brief.txt, cat CODE_1.dat`,
+          stderr: '',
+          exitCode: 0,
+          success: true,
+          currentWorkingDirectory: currentDir,
+          isSimulated: true
+        });
+      } else if (currentDir === '/var/games/level2' && (dirPath === '.' || dirPath === 'level2')) {
+        const level2Files = [
+          'drwxr-xr-x 1 games games 4096 Dec 25 12:00 .',
+          'drwxr-xr-x 1 games games 4096 Dec 25 12:00 ..',
+          '-rw-r--r-- 1 games games  210 Dec 25 12:00 network.log',
+          '-rw-r--r-- 1 games games  178 Dec 25 12:00 puzzle.txt'
+        ];
+
+        return NextResponse.json({
+          stdout: `📡 SIDE QUEST FILES\n\ntotal 8\n${level2Files.join('\n')}\n\n💡 Try: cat puzzle.txt`,
           stderr: '',
           exitCode: 0,
           success: true,
@@ -300,6 +322,17 @@ Once you have all 3 codes, check 'victory.txt'!
             currentWorkingDirectory: '/var/games/intel',
             isSimulated: true
           });
+        } else if (targetPath === 'level2' || targetPath === './level2') {
+          // Side quest directory
+          shellExecutor.setCurrentWorkingDirectory('/var/games/level2');
+          return NextResponse.json({
+            stdout: '',
+            stderr: '',
+            exitCode: 0,
+            success: true,
+            currentWorkingDirectory: '/var/games/level2',
+            isSimulated: true
+          });
         } else if (targetPath === 'vault' || targetPath === './vault') {
           // Simulate entering vault directory (but require password later)
           shellExecutor.setCurrentWorkingDirectory('/var/games/vault');
@@ -336,6 +369,17 @@ Once you have all 3 codes, check 'victory.txt'!
         }
       } else if (currentDir === '/var/games/intel' && (targetPath === '..' || targetPath === '../')) {
         // Go back to /var/games from intel
+        shellExecutor.setCurrentWorkingDirectory('/var/games');
+        return NextResponse.json({
+          stdout: '',
+          stderr: '',
+          exitCode: 0,
+          success: true,
+          currentWorkingDirectory: '/var/games',
+          isSimulated: true
+        });
+      } else if (currentDir === '/var/games/level2' && (targetPath === '..' || targetPath === '../')) {
+        // Go back to /var/games from level2
         shellExecutor.setCurrentWorkingDirectory('/var/games');
         return NextResponse.json({
           stdout: '',

--- a/src/utils/filesystem.ts
+++ b/src/utils/filesystem.ts
@@ -133,7 +133,7 @@ export const createInitialFileSystem = (): FileSystemNode => ({
               size: 445,
               modified: new Date(),
               content:
-                "🕵️ HACKER CHALLENGE INSTRUCTIONS\n\n1. INTEL GATHERING:\n   - Navigate to 'intel' directory\n   - Read all intelligence files\n   - Find CODE_1\n\n2. MATRIX DECODING:\n   - Check 'matrix.dat' file\n   - Decode the pattern to find CODE_2\n\n3. VAULT CRACKING:\n   - Enter the vault with the secret password\n   - Complete the puzzle for CODE_3\n\nOnce you have all 3 codes, check 'victory.txt'!\n\n💡 HINTS:\n- Use 'ls -la' to see hidden files\n- Some files need special commands\n- The password was mentioned somewhere...",
+                "🕵️ HACKER CHALLENGE INSTRUCTIONS\n\n1. INTEL GATHERING:\n   - Navigate to 'intel' directory\n   - Read all intelligence files\n   - Find CODE_1\n\n2. MATRIX DECODING:\n   - Check 'matrix.dat' file\n   - Decode the pattern to find CODE_2\n\n3. VAULT CRACKING:\n   - Enter the vault with the secret password\n   - Complete the puzzle for CODE_3\n\n▶ BONUS LEVEL:\n   - Explore the 'level2' directory for a side quest\n   - Record your name in 'scoreboard.txt' to save your score\n\nOnce you have all 3 codes, check 'victory.txt'!\n\n💡 HINTS:\n- Use 'ls -la' to see hidden files\n- Some files need special commands\n- The password was mentioned somewhere...",
             },
             intel: {
               name: "intel",
@@ -189,6 +189,37 @@ export const createInitialFileSystem = (): FileSystemNode => ({
               content:
                 "🔢 MATRIX DECODING CHALLENGE\n\n01000010 01000101 01010100 01000001\n01011000 01011001 01011010 01000101 \n01000101 01001001 01000111 01001000\n01010100 01011111 01000110 01001111\n01010101 01010010 01000101 01011000\n\n💡 HINT: This is binary code!\n💡 Each group of 8 bits = 1 letter\n💡 Convert to ASCII to reveal CODE_2\n\n🔍 Answer format: CODE_2: [YOUR_DECODED_MESSAGE]",
             },
+            level2: {
+              name: "level2",
+              type: "directory",
+              permissions: "drwxr-xr-x",
+              owner: "games",
+              group: "games",
+              size: 4096,
+              modified: new Date(),
+              children: {
+                "network.log": {
+                  name: "network.log",
+                  type: "file",
+                  permissions: "-rw-r--r--",
+                  owner: "games",
+                  group: "games",
+                  size: 210,
+                  modified: new Date(),
+                  content: "📡 INTERCEPTED NETWORK TRAFFIC\n\n[PACKET] 45 00 00 54...\n[PACKET] 45 00 00 28...\n\nHidden within the noise lies a secret word. Can you spot it?",
+                },
+                "puzzle.txt": {
+                  name: "puzzle.txt",
+                  type: "file",
+                  permissions: "-rw-r--r--",
+                  owner: "games",
+                  group: "games",
+                  size: 178,
+                  modified: new Date(),
+                  content: "🧩 SIDE QUEST RIDDLE\n\nI'm the key to many doors, yet I have no lock.\nBreak my code to reveal the bonus phrase.\nHint: Caesar liked to shift things by 13.",
+                },
+              },
+            },
             vault: {
               name: "vault",
               type: "directory",
@@ -221,6 +252,16 @@ export const createInitialFileSystem = (): FileSystemNode => ({
                 },
               },
             },
+            "scoreboard.txt": {
+              name: "scoreboard.txt",
+              type: "file",
+              permissions: "-rw-r--r--",
+              owner: "games",
+              group: "games",
+              size: 138,
+              modified: new Date(),
+              content: "🏆 HACKER SCOREBOARD\n\nAdd your alias and completion time using:\n  echo \"NAME - TIME\" > scoreboard.txt\n\nTop score will be displayed here!",
+            },
             "victory.txt": {
               name: "victory.txt",
               type: "file",
@@ -230,7 +271,7 @@ export const createInitialFileSystem = (): FileSystemNode => ({
               size: 445,
               modified: new Date(),
               content:
-                "🎉 CONGRATULATIONS HACKER! 🎉\n\nYou've successfully completed the Cyber Hack Challenge!\n\n✅ CODE_1: ALPHA_SEVEN_NINE (from intel)\n✅ CODE_2: BETAXYZE EIGHTFOUREX (from matrix)\n✅ CODE_3: FIRE_MASTER (from vault)\n\n🏆 ACHIEVEMENT UNLOCKED: Master Hacker\n\nYou've proven yourself worthy!\nWelcome to the elite hackers club! 😎\n\n🎮 Want more challenges? Check out /opt/retro for classic games!\n\nThank you for playing!\n- The Berto Game Master",
+                "🎉 CONGRATULATIONS HACKER! 🎉\n\nYou've successfully completed the Cyber Hack Challenge!\n\n✅ CODE_1: ALPHA_SEVEN_NINE (from intel)\n✅ CODE_2: BETAXYZE EIGHTFOUREX (from matrix)\n✅ CODE_3: FIRE_MASTER (from vault)\n\n🏆 ACHIEVEMENT UNLOCKED: Master Hacker\n\nAdd your alias to 'scoreboard.txt' and claim the top spot!\nWelcome to the elite hackers club! 😎\n\n🎮 Want more challenges? Check out /opt/retro for classic games!\n\nThank you for playing!\n- The Berto Game Master",
             },
           },
         },


### PR DESCRIPTION
## Summary
- add optional side quest and scoreboard files
- support level2 directory navigation and listing
- update fallback instructions for the hack challenge
- document new hack-game features in README

## Testing
- `pnpm lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_685e04c93e5c83269106aa49be91426c